### PR TITLE
Random features, length scale

### DIFF
--- a/torchkernels/demos/random_features_logistic_regression.py
+++ b/torchkernels/demos/random_features_logistic_regression.py
@@ -1,0 +1,10 @@
+from torchkernels.feature_maps import LaplacianRFF
+from torchvision.datasets import FMNIST
+import os
+
+data = FMNIST(os.environ['DATASETS_DIR'])
+
+feature_map = LaplacianRFF()
+Phi = feature_map(X)
+
+# code for logistic regression

--- a/torchkernels/feature_maps/__init__.py
+++ b/torchkernels/feature_maps/__init__.py
@@ -1,0 +1,40 @@
+import torch
+import torch.distributions as dist
+def CMS_sampling(p, alpha, length_scale=1.):
+    r"""
+    Generate radial CMS given alpha, length_scale and dimension d. Samples generated are from $S(\alpha/2, 1, $2 \gamma^2 (cos(\pi \alpha/2))^(2/\alpha)$, 0)
+    
+    Parameters:
+        p (int): Number of samples
+        alpha (float): alpha for the multivariable alpha-stable distribution
+        length_scale (float): length_scale for the distribution, default is 1.
+    
+    Returns:
+        x (torch.tensor), shape (n,)): generated CMS samples
+    """
+    PI = torch.tensor(torch.pi)
+    gamma_2 = 1/(length_scale**2)
+    sigma = 2 * gamma_2* ((PI*alpha/4).cos())**(2/alpha)
+    if not 0. < alpha < 2.:
+        raise ValueError("Alpha must be between 0 and 2, both excluded")
+    v = torch.rand(p)*PI - PI/2
+    w = dist.exponential.Exponential(torch.tensor(1.)).sample((p,))
+    
+    alpha = alpha/2
+    if alpha == 1.:
+        raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
+    elif alpha == 2.:
+        raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
+    else:
+        arg1 = PI/2 * alpha
+        b_ab = PI/2
+        s_ab = torch.pow(arg1.cos(),-1/alpha)
+        arg2 = alpha * (v + b_ab)
+        n1 = arg2.sin()
+        d1 = torch.pow(v.cos(),1/alpha)
+        n2 = (v-arg2).cos()
+        x = sigma * s_ab * (n1/d1) * torch.pow(n2/w, (1-alpha)/alpha)
+        return x
+
+# if __name__ == "__main__":
+#     print(CMS_sampling(p=100, alpha=0.7, length_scale=1.))

--- a/torchkernels/feature_maps/__init__.py
+++ b/torchkernels/feature_maps/__init__.py
@@ -1,42 +1,4 @@
-import numpy as np
-import scipy.stats as stats
-def CMS_sampling(p, alpha, length_scale=1.):
-    r"""
-    Generate radial CMS given alpha, length_scale and dimension d. Samples generated are from $S(\alpha/2, 1, $2 \gamma^2 (cos(\pi \alpha/2))^(2/\alpha)$, 0)
-    
-    Parameters:
-        p (int): Number of samples
-        alpha (float): alpha for the multivariable alpha-stable distribution
-        length_scale (float): length_scale for the distribution, default is 1.
-    
-    Returns:
-        x (torch.tensor), shape (n,)): generated CMS samples
-    """
-    PI = np.pi
-    gamma_2 = 1/(float(length_scale))**2
-    sigma = 2 * gamma_2* (np.cos(PI*alpha/4))**(2/alpha)
-    if not 0. <= alpha <= 2.:
-        raise ValueError("Alpha must be between 0 and 2")
-    # generate random variables
-    v = np.random.uniform(-0.5 * PI, 0.5 * PI, p)
-    w = np.random.exponential(1, p)
-    
-    #alpha to be used in CMS is alpha/2 given alpha for multivariable stable distribution
-    alpha = float(alpha)/2
-    if alpha == 1.:
-        raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
-    elif alpha == 2.:
-        raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
-    else:
-        arg1 = 0.5 * PI * alpha
-        b_ab = PI/2
-        s_ab = np.cos(arg1)**(-1/alpha)
-        arg2 = alpha * (v + b_ab)
-        n1 = np.sin(arg2)
-        d1 = np.cos(v)**(1/alpha)
-        n2 = np.cos(v - arg2)
-        x = sigma * s_ab * (n1/d1) * (n2/w)**((1-alpha)/alpha)
-        return x
-
-# if __name__ == "__main__":
-#     print(CMS_sampling(p=100, alpha=0.7, length_scale=1.))
+from .gaussian import GaussianORF, GaussianRFF
+from .laplacian import LaplacianORF, LaplacianRFF
+from .exp_power import ExpPowerORF, ExpPowerRFF
+from .matern import MaternORF, MaternRFF

--- a/torchkernels/feature_maps/exponential_power.py
+++ b/torchkernels/feature_maps/exponential_power.py
@@ -1,1 +1,0 @@
-raise NotImplementedError

--- a/torchkernels/feature_maps/gaussian.py
+++ b/torchkernels/feature_maps/gaussian.py
@@ -1,1 +1,0 @@
-raise NotImplementedError

--- a/torchkernels/feature_maps/laplacian.py
+++ b/torchkernels/feature_maps/laplacian.py
@@ -1,1 +1,0 @@
-raise NotImplementedError

--- a/torchkernels/feature_maps/laplacian.py
+++ b/torchkernels/feature_maps/laplacian.py
@@ -1,0 +1,20 @@
+from .orf import ORF
+from .rff import RFF
+
+class LaplacianORF(ORF):
+
+  def set_S():
+    self.S = ...
+
+class LaplacianRFF(RFF):
+  
+  def set_W2():
+    self.W2 = ...
+
+  def apply_W2(self):
+    return ...
+
+if __name__=="__main__":
+  phi = LaplacianORF()
+  Phi1 = phi(X1)
+  Phi2 = phi(X2)

--- a/torchkernels/feature_maps/laplacian.py
+++ b/torchkernels/feature_maps/laplacian.py
@@ -15,6 +15,12 @@ class LaplacianRFF(RFF):
     return ...
 
 if __name__=="__main__":
-  phi = LaplacianORF()
-  Phi1 = phi(X1)
-  Phi2 = phi(X2)
+  feature_map = LaplacianORF()
+  n,p,d=10,2,7
+  X = torch.randn(n,d)
+  W1 = torch.randn(d,p)
+  W2 = torch.randn(p)
+  feature_map.set_W1(W1)
+  feature_map.set_W2(W2)
+  assert torch.allclose(feature_map(X),sincos((X@W1)/W2))
+

--- a/torchkernels/feature_maps/matern.py
+++ b/torchkernels/feature_maps/matern.py
@@ -1,1 +1,0 @@
-raise NotImplementedError

--- a/torchkernels/feature_maps/orf.py
+++ b/torchkernels/feature_maps/orf.py
@@ -7,6 +7,9 @@ class ORF:
   def __call__(x):
     return (x @ self.Q) * self.S
 
+  def set_Q(Q):
+    self.Q = Q
+
   def set_S():
     raise NotImplementedError(
       "This method must be implemented in the subclass")

--- a/torchkernels/feature_maps/orf.py
+++ b/torchkernels/feature_maps/orf.py
@@ -1,0 +1,12 @@
+class ORF:
+
+  def __init__(input_dim,num_features):
+    self.Q = ...
+    self.set_S()
+
+  def __call__(x):
+    return (x @ self.Q) * self.S
+
+  def set_S():
+    raise NotImplementedError(
+      "This method must be implemented in the subclass")

--- a/torchkernels/feature_maps/orthogonal_random_features.py
+++ b/torchkernels/feature_maps/orthogonal_random_features.py
@@ -2,6 +2,7 @@ from .__init__ import CMS_sampling
 import torch
 import scipy.stats as stats
 import numpy as np
+import math
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -41,14 +42,14 @@ def ORF_w(p_feat, d_dim, Kernel='Laplace', length_scale=1., nu=None, alpha=None)
         elif Kernel == "Matern":
             Rad_dist = np.sqrt(stats.betaprime.rvs(d_dim/2, nu, size=p_feat))*np.sqrt(2*nu)/length_scale
         elif Kernel == "ExpPower":
-            Rad_dist = radial_CMS(p=p_feat, d=d_dim, alpha=alpha, length_scale=length_scale)
+            Rad_dist = radial_CMS(p_feat=p_feat, d_dim=d_dim, alpha=alpha, length_scale=length_scale)
         for _ in range(int(np.ceil(p_feat/d_dim))):
             Q = stats.ortho_group.rvs(dim=d_dim)
             Q_arr.append(Q)
         Q = np.concatenate(Q_arr, axis=0)
         del Q_arr
-        return torch.from_numpy((Q[:p_feat]).T), torch.from_numpy(Rad_dist)
-
+        return torch.from_numpy((Q[:p_feat]).T).to(torch.float32), torch.from_numpy(Rad_dist).to(dtype=torch.float32)
+    
 def radial_CMS(p_feat, d_dim, alpha, length_scale=1.):
         """
     Arguments
@@ -71,15 +72,51 @@ def radial_CMS(p_feat, d_dim, alpha, length_scale=1.):
         x = CMS_sampling(p=p_feat, alpha=alpha, length_scale=length_scale)
         y = stats.chi.rvs(d_dim, size=p_feat)
         return x*y
+
+class Orthogonal_Random_Features:
+    def __init__(self, p_feat, d_dim, kernel="Laplace", Rf_bias:bool=False, length_scale=1., nu=None, alpha=None):
+        assert kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+        if kernel == "Matern": assert nu is not None
+        if kernel == "ExpPower": 
+            assert alpha is not None
+            assert 0 < alpha <= 2
+            if alpha==1: raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
+            if alpha==2: raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
+
+        
+        self.p_feat = p_feat
+        self.d_dim = d_dim
+        self.kernel = kernel
+        self.length_scale = length_scale
+        self.nu = nu
+        self.alpha = alpha
+        self.Rf_bias = Rf_bias
+        if not Rf_bias: p_feat = p_feat // 2
+        self.Q, self.Rad_dist = ORF_w(p_feat=p_feat, d_dim=self.d_dim, Kernel=self.kernel, length_scale=self.length_scale, nu=self.nu, alpha=self.alpha)
+        self.b = ((torch.rand(self.p_feat) * math.pi * 2).to(DEVICE))
     
-def create_ORF(p_feat, X_, kernel='Laplace', Rf_bias:bool=False, length_scale:float=1., nu=None, alpha=None) -> torch.tensor:
+    def __call__(self, X_):
+        Q = self.Q.to(DEVICE)  # On GPU
+        R_dist = self.Rad_dist.to(DEVICE)  # On GPU
+        c1 = (torch.sqrt(torch.tensor(2 / self.p_feat)).to(DEVICE))  # On GPU
+        
+        torch.cuda.empty_cache()
+        X_ = X_.to(DEVICE)  # On GPU
+        if self.Rf_bias:
+            return c1 * ((torch.mm(X_, Q)*R_dist) + self.b).cos()
+        else:
+            return c1 * torch.cat([(torch.mm(X_, Q)*R_dist).cos(), (torch.mm(X_, Q)*R_dist).sin()], dim=-1)
+
+def create_ORF(Q, R_dist, X_, kernel='Laplace', Rf_bias:bool=False, length_scale:float=1., nu=None, alpha=None) -> torch.tensor:
     """
     Generate random features using Orthogonal Random Features (ORF) method.
 
     Parameters
     ----------
-    p_feat : int    
-        Number of random features.
+    Q : torch.tensor
+        Stacked up orthogonal matrix.
+    R_dist : torch.tensor
+        Radial distribution vector.
     X_ : torch.tensor
         Input data tensor.
     kernel : str, optional
@@ -112,7 +149,7 @@ def create_ORF(p_feat, X_, kernel='Laplace', Rf_bias:bool=False, length_scale:fl
         p_feat = p_feat // 2
     
     d_dim = X_.shape[1]
-    Q, R_dist = ORF_w(p=p_feat, d=d_dim, Kernel=kernel, length_scale=length_scale, nu=nu, alpha=alpha)
+    # Q, R_dist = ORF_w(p_feat=p_feat, d_dim=d_dim, Kernel=kernel, length_scale=length_scale, nu=nu, alpha=alpha)
     Q = Q.to(DEVICE)  # On GPU
     R_dist = R_dist.to(DEVICE)  # On GPU
     b = ((torch.rand(p_feat) * torch.pi * 2).to(DEVICE))  # On GPU

--- a/torchkernels/feature_maps/orthogonal_random_features.py
+++ b/torchkernels/feature_maps/orthogonal_random_features.py
@@ -1,0 +1,126 @@
+from .__init__ import CMS_sampling
+import torch
+import scipy.stats as stats
+import numpy as np
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+def ORF_w(p_feat, d_dim, Kernel='Laplace', length_scale=1., nu=None, alpha=None):
+        """
+    Generate Q and Rad_dist for ORF feature map
+    
+    Arguments
+    ----------
+    p_feat : int
+        Number of random features
+    d_dim : int
+        dimension of underlying problem 
+    Kernel : str
+        Kernel type, options are ['Laplace', 'Gauss', 'Matern', 'ExpPower']
+    length_scale : float
+        length_scale for the kernel
+    nu : float
+        shape parameter for Matern kernel, ignored if kernel is not Matern
+    alpha : float
+        stability parameter for ExpPower kernel, ignored if kernel is not ExpPower
+    
+    Returns
+    -------
+    Q : torch.tensor, shape (D, d_dim)
+        Orthogonal transform
+    Rad_dist : torch.tensor, shape (D,)
+        Radial distribution
+    """
+        
+        Q_arr = []
+        
+        if Kernel == "Laplace":
+            Rad_dist = np.sqrt(stats.betaprime.rvs(d_dim/2,1/2, size=p_feat))/length_scale
+        elif Kernel =="Gauss":
+            Rad_dist = stats.chi.rvs(d_dim,size=p_feat)/length_scale
+        elif Kernel == "Matern":
+            Rad_dist = np.sqrt(stats.betaprime.rvs(d_dim/2, nu, size=p_feat))*np.sqrt(2*nu)/length_scale
+        elif Kernel == "ExpPower":
+            Rad_dist = radial_CMS(p=p_feat, d=d_dim, alpha=alpha, length_scale=length_scale)
+        for _ in range(int(np.ceil(p_feat/d_dim))):
+            Q = stats.ortho_group.rvs(dim=d_dim)
+            Q_arr.append(Q)
+        Q = np.concatenate(Q_arr, axis=0)
+        del Q_arr
+        return torch.from_numpy((Q[:p_feat]).T), torch.from_numpy(Rad_dist)
+
+def radial_CMS(p_feat, d_dim, alpha, length_scale=1.):
+        """
+    Arguments
+    ----------
+    p_feat : int
+        Number of random features
+    d_dim : int
+        dimension of underlying problem
+    alpha : float
+        stability parameter for ExpPower kernel, ignored if kernel is not ExpPower
+    length_scale : float
+        length_scale for the kernel
+
+    Returns
+    -------
+    x : torch.tensor, shape (p_feat,)
+        Radial distribution
+    """
+    # Generate radial CMS given alpha, bw (bandwidth)
+        x = CMS_sampling(p=p_feat, alpha=alpha, length_scale=length_scale)
+        y = stats.chi.rvs(d_dim, size=p_feat)
+        return x*y
+    
+def create_ORF(p_feat, X_, kernel='Laplace', Rf_bias:bool=False, length_scale:float=1., nu=None, alpha=None) -> torch.tensor:
+    """
+    Generate random features using Orthogonal Random Features (ORF) method.
+
+    Parameters
+    ----------
+    p_feat : int    
+        Number of random features.
+    X_ : torch.tensor
+        Input data tensor.
+    kernel : str, optional
+        Type of kernel to use; options are ['Laplace', 'Gauss', 'Matern', 'ExpPower'].
+        Defaults to 'Laplace'.
+    Rf_bias : bool, optional
+        Whether to include a bias term in the random features. Defaults to False.
+    length_scale : float, optional
+        Length scale for the kernel. Defaults to 1.
+    nu : float, optional
+        Shape parameter for the Matern kernel, required if kernel is 'Matern'.
+    alpha : float, optional
+        Stability parameter for the ExpPower kernel, required if kernel is 'ExpPower'.
+
+    Returns
+    -------
+    torch.tensor
+        The generated random features.
+    """
+
+    assert kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+    if kernel == "Matern": assert nu is not None
+    if kernel == "ExpPower": 
+        assert alpha is not None
+        assert 0 < alpha <= 2
+        if alpha==1: raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
+        if alpha==2: raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
+
+    if not Rf_bias:
+        p_feat = p_feat // 2
+    
+    d_dim = X_.shape[1]
+    Q, R_dist = ORF_w(p=p_feat, d=d_dim, Kernel=kernel, length_scale=length_scale, nu=nu, alpha=alpha)
+    Q = Q.to(DEVICE)  # On GPU
+    R_dist = R_dist.to(DEVICE)  # On GPU
+    b = ((torch.rand(p_feat) * torch.pi * 2).to(DEVICE))  # On GPU
+    c1 = (torch.sqrt(torch.tensor(2 / p_feat)).to(DEVICE))  # On GPU
+    
+    torch.cuda.empty_cache()
+    X_ = X_.to(DEVICE)  # On GPU
+    if Rf_bias:
+        return c1 * ((torch.mm(X_, Q)*R_dist) + b).cos()
+    else:
+        return c1 * torch.cat([(torch.mm(X_, Q)*R_dist).cos(), (torch.mm(X_, Q)*R_dist).sin()], dim=-1)

--- a/torchkernels/feature_maps/orthogonal_random_features.py
+++ b/torchkernels/feature_maps/orthogonal_random_features.py
@@ -71,7 +71,7 @@ def radial_CMS(p_feat, d_dim, alpha, length_scale=1.):
     # Generate radial CMS given alpha, bw (bandwidth)
         x = CMS_sampling(p=p_feat, alpha=alpha, length_scale=length_scale)
         y = stats.chi.rvs(d_dim, size=p_feat)
-        return x*y
+        return np.sqrt(x)*y
 
 class Orthogonal_Random_Features:
     def __init__(self, p_feat, d_dim, kernel="Laplace", Rf_bias:bool=False, length_scale=1., nu=None, alpha=None):

--- a/torchkernels/feature_maps/random_features_test.py
+++ b/torchkernels/feature_maps/random_features_test.py
@@ -1,32 +1,42 @@
 from ..kernels.radial import laplacian, gaussian, exp_power, matern
-from .orthogonal_random_features import create_ORF
-# from .random_fourier_features import create_RFF
+from .orthogonal_random_features import Orthogonal_Random_Features
+from .random_fourier_features import Random_Fourier_Features
 import torch
 import matplotlib.pyplot as plt
 import numpy as np
 
 print("Imports done")
-def test_kernel_approximation(d=32, D=int(1e5), bandwidth=1., alpha=0.5, nu=1.5, App_type="ORF", Kernel = 'ExpPower'):
-    assert Kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+def test_kernel_approximation(d=10, D=int(1e3), length_scale=1., alpha=0.7, nu=1.5, App_type="ORF", Rf_bias:bool=False, kernel = 'ExpPower'):
+    assert kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
     K_func = {"Laplace": laplacian, "Gauss": gaussian, "Matern": matern, "ExpPower": exp_power}
-    N = int(50)
-    x1_x2_norm = np.linspace(0, 5, N)
+    N = int(10)
+    x1_x2_norm = np.linspace(0, 1, N)
     K_mat_exact = []
     K_mat_approx = []
+    print(alpha)
+    if App_type == "ORF":
+        RF_obj = Orthogonal_Random_Features(p_feat=D, d_dim=d, kernel=kernel, Rf_bias=Rf_bias, length_scale=length_scale, nu=nu, alpha=alpha)
+    elif App_type == "RFF":
+        RF_obj = Random_Fourier_Features(p_feat=D, d_dim=d, kernel=kernel, Rf_bias=Rf_bias, length_scale=length_scale, nu=nu, alpha=alpha)
+    else:
+        raise ValueError("App_type must be either 'ORF' or 'RFF'")
+
     for i, x_ in enumerate(x1_x2_norm):
         x1 = torch.randn(d)
         x1_x2_u = torch.randn(d)
         x1_x2 = x1_x2_u/np.linalg.norm(x1_x2_u)*x_
         x2 = x1 + x1_x2
-        ORF_Phi_x1 = create_ORF(p_feat=D, X_=x1, kernel=Kernel, Rf_bias=False, length_scale=bandwidth, nu=nu, alpha=alpha)
-        ORF_Phi_x2 = create_ORF(p_feat=D, X_=x2, kernel=Kernel, Rf_bias=False, length_scale=bandwidth, nu=nu, alpha=alpha)
-        K_mat_approx.append(torch.dot(ORF_Phi_x1, ORF_Phi_x2).item())
         x1 = x1.reshape(1,-1)
         x2 = x2.reshape(1,-1)
-        K_mat_exact.append(K_func[Kernel](x1_x2, bandwidth=bandwidth, nu=nu, alpha=alpha))
+        Phi_x1 = RF_obj(x1)
+        Phi_x2 = RF_obj(x2)
+        print(Phi_x1.shape, Phi_x2.shape)
+        K_mat_approx.append((Phi_x1@Phi_x2.T)[0].item())
+        K_mat_exact.append(K_func[kernel](x1, x2, length_scale=length_scale, alpha=alpha)[0].item())
     plt.figure(figsize=(6, 6))
-    plt.plot(x1_x2_norm, K_mat_exact, label=f'Laplace kernel (bandwidth={bandwidth})')
-    plt.scatter(x1_x2_norm, K_mat_approx, label = 'RFF Estimate', alpha=0.5, color='red')
+    plt.scatter(x1_x2_norm, K_mat_approx, label = f'{App_type} Estimate', alpha=0.5, color='red')
+    print(K_mat_approx[:10])
+    plt.plot(x1_x2_norm, K_mat_exact, label=f'exact')
     plt.ylim(1e-4, 1.5)
     plt.xlabel("||x-z||")
     plt.xticks(fontsize=12)
@@ -35,5 +45,7 @@ def test_kernel_approximation(d=32, D=int(1e5), bandwidth=1., alpha=0.5, nu=1.5,
     plt.legend()
     plt.show()
 
-if __name__ == '__main__':
-    test_kernel_approximation()
+test_kernel_approximation(d=32, D=int(1e5), length_scale=1., alpha=0.7, nu=1.5, App_type="ORF", Rf_bias=True, kernel = 'ExpPower')
+
+# if __name__ == '__main__':
+    # test_kernel_approximation()

--- a/torchkernels/feature_maps/random_features_test.py
+++ b/torchkernels/feature_maps/random_features_test.py
@@ -1,0 +1,39 @@
+from ..kernels.radial import laplacian, gaussian, exp_power, matern
+from .orthogonal_random_features import create_ORF
+# from .random_fourier_features import create_RFF
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+
+print("Imports done")
+def test_kernel_approximation(d=32, D=int(1e5), bandwidth=1., alpha=0.5, nu=1.5, App_type="ORF", Kernel = 'ExpPower'):
+    assert Kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+    K_func = {"Laplace": laplacian, "Gauss": gaussian, "Matern": matern, "ExpPower": exp_power}
+    N = int(50)
+    x1_x2_norm = np.linspace(0, 5, N)
+    K_mat_exact = []
+    K_mat_approx = []
+    for i, x_ in enumerate(x1_x2_norm):
+        x1 = torch.randn(d)
+        x1_x2_u = torch.randn(d)
+        x1_x2 = x1_x2_u/np.linalg.norm(x1_x2_u)*x_
+        x2 = x1 + x1_x2
+        ORF_Phi_x1 = create_ORF(p_feat=D, X_=x1, kernel=Kernel, Rf_bias=False, length_scale=bandwidth, nu=nu, alpha=alpha)
+        ORF_Phi_x2 = create_ORF(p_feat=D, X_=x2, kernel=Kernel, Rf_bias=False, length_scale=bandwidth, nu=nu, alpha=alpha)
+        K_mat_approx.append(torch.dot(ORF_Phi_x1, ORF_Phi_x2).item())
+        x1 = x1.reshape(1,-1)
+        x2 = x2.reshape(1,-1)
+        K_mat_exact.append(K_func[Kernel](x1_x2, bandwidth=bandwidth, nu=nu, alpha=alpha))
+    plt.figure(figsize=(6, 6))
+    plt.plot(x1_x2_norm, K_mat_exact, label=f'Laplace kernel (bandwidth={bandwidth})')
+    plt.scatter(x1_x2_norm, K_mat_approx, label = 'RFF Estimate', alpha=0.5, color='red')
+    plt.ylim(1e-4, 1.5)
+    plt.xlabel("||x-z||")
+    plt.xticks(fontsize=12)
+    plt.yticks(fontsize=12)
+    # plt.yscale('log')
+    plt.legend()
+    plt.show()
+
+if __name__ == '__main__':
+    test_kernel_approximation()

--- a/torchkernels/feature_maps/random_fourier_features.py
+++ b/torchkernels/feature_maps/random_fourier_features.py
@@ -1,0 +1,110 @@
+from __init__ import CMS_sampling
+import torch
+from torch.distributions.chi2 import Chi2
+import scipy.stats as stats
+import numpy as np
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def RFF_w(p_feat, d_dim, Kernel="Laplace", length_scale=1., nu=None, alpha=None, file_handle=None):
+    """
+    Generate 1 weight matrices Random Fourier Features (RFF) method with specified kernel. 
+    For the Laplace and the Matern kernel W = W1/W2.
+    For the ExpPower kernel W = W1*W2.
+    For the Gaussian kernel W2 is just all ones.
+
+    Parameters
+    ----------
+    p_feat : int    
+        Number of random features.
+    d_dim : int
+        dimension of underlying dataset 
+    Kernel : str
+        Kernel type, options are ['Laplace', 'Gauss', 'Matern', 'ExpPower']
+    length_scale : float
+        length_scale for the kernel
+    nu : float
+        shape parameter for Matern kernel, ignored if kernel is not Matern
+    alpha : float
+        stability parameter for ExpPower kernel, ignored if kernel is not ExpPower
+
+    Returns
+    -------
+    W1 : torch.tensor, shape (d_dim, p_feat)
+        W1 for RFF
+    W2 : torch.tensor, shape (p_feat,)
+        W2 for RFF
+        
+    """
+    assert Kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+    if Kernel == "Laplace":
+        return torch.randn(d_dim,p_feat)*length_scale , torch.randn(p_feat)
+    elif Kernel =="Gauss":
+        return torch.randn(d_dim,p_feat)*length_scale , torch.ones(p_feat)
+    elif Kernel == "Matern":
+        df=2*nu
+        chi2_dist = Chi2(df=df)
+        chi2_samples = chi2_dist.sample((p_feat,))/(2*nu)
+        return torch.randn(d_dim,p_feat)/length_scale , torch.sqrt(chi2_samples)
+    elif Kernel == "ExpPower":
+        return torch.randn(d_dim,p_feat), torch.sqrt(CMS_sampling(n=p_feat, d=d_dim, alpha=alpha, length_scale=length_scale))
+    
+def create_RFF(p_feat, X_, kernel='Laplace', Rf_bias:bool=False, length_scale:float=1., nu=None, alpha=None) -> torch.tensor:
+    """
+    Generate random features using Orthogonal Random Features (ORF) method.
+
+    Parameters
+    ----------
+    p_feat : int    
+        Number of random features.
+    X_ : torch.tensor
+        Input data tensor.
+    kernel : str, optional
+        Type of kernel to use; options are ['Laplace', 'Gauss', 'Matern', 'ExpPower'].
+        Defaults to 'Laplace'.
+    Rf_bias : bool, optional
+        Whether to include a bias term in the random features. Defaults to False.
+    length_scale : float, optional
+        Length scale for the kernel. Defaults to 1.
+    nu : float, optional
+        Shape parameter for the Matern kernel, required if kernel is 'Matern'.
+    alpha : float, optional
+        Stability parameter for the ExpPower kernel, required if kernel is 'ExpPower'.
+
+    Returns
+    -------
+    torch.tensor
+        The generated random features.
+    """
+
+    assert kernel in ["Laplace", "Gauss", "Matern", "ExpPower"]
+    if kernel == "Matern": assert nu is not None
+    if kernel == "ExpPower": 
+        assert alpha is not None
+        assert 0 < alpha <= 2
+        if alpha==1: raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
+        if alpha==2: raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
+
+    if not Rf_bias:
+        p_feat = p_feat // 2
+    
+    d_dim = X_.shape[1]
+    W1, W2 = RFF_w(D=p_feat, d=d_dim, Kernel=kernel, length_scale=length_scale, nu=nu, alpha=alpha)
+    W1 = W1.to(DEVICE)  # On GPU
+    W2 = W2.to(DEVICE)  # On GPU
+    b = ((torch.rand(p_feat) * torch.pi * 2).to(DEVICE))  # On GPU
+    c1 = (torch.sqrt(torch.tensor(2 / p_feat)).to(DEVICE))  # On GPU
+    
+    torch.cuda.empty_cache()
+    X_ = X_.to(DEVICE)  # On GPU
+    if Rf_bias:
+        if kernel in ['Laplace', 'Matern']:
+            return c1 * ((torch.mm(X_, W1)/W2) + b).cos()
+        elif kernel in ['Gauss', 'ExpPower']:
+            return c1 * ((torch.mm(X_, W1)*W2) + b).cos()
+    else:
+        if kernel in ['Laplace', 'Matern']:
+            return c1 * torch.cat([(torch.mm(X_, W1)/W2).cos(), (torch.mm(X_, W1)/W2).sin()], dim=-1)
+        elif kernel in ['Gauss', 'ExpPower']:
+            return c1 * torch.cat([(torch.mm(X_, W1)*W2).cos(), (torch.mm(X_, W1)*W2).sin()], dim=-1)

--- a/torchkernels/feature_maps/rff.py
+++ b/torchkernels/feature_maps/rff.py
@@ -7,6 +7,9 @@ class RFF:
   def __call__():
     return self.apply_W2(x @ self.W1)
 
+  def set_W1(W1):
+    self.W1 = W1
+
   def set_W2(self):
     raise NotImplementedError("This method must be implemented in the subclass")
 

--- a/torchkernels/feature_maps/rff.py
+++ b/torchkernels/feature_maps/rff.py
@@ -1,0 +1,14 @@
+class RFF:
+
+  def __init__():
+    self.W1 = ...
+    self.set_W2()
+    
+  def __call__():
+    return self.apply_W2(x @ self.W1)
+
+  def set_W2(self):
+    raise NotImplementedError("This method must be implemented in the subclass")
+
+  def apply_W2(self):
+    raise NotImplementedError("This method must be implemented in the subclass")

--- a/torchkernels/feature_maps/ridge_regression/__init__.py
+++ b/torchkernels/feature_maps/ridge_regression/__init__.py
@@ -1,0 +1,39 @@
+import termcolor
+class FormattedFileWriter:
+    """A class for writing formatted output to a file with optional ANSI formatting.
+    
+    Attributes:
+        file_path (str): Path to the file where the output will be written.
+        use_formatting (bool): Indicates whether formatting should be applied 
+                               based on file extension.
+    """
+
+    def __init__(self, file_path: str):
+        """Initializes the FormattedFileWriter with the file path.
+
+        Args:
+            file_path (str): The path to the file where the output will be written.
+        """
+        if file_path is None:
+            raise ValueError("file_path cannot be None")
+        self.file_path = file_path
+        self.use_formatting = file_path.endswith(('.ans', '.ansi'))
+
+    def write(self, text: str, color: str = None, on_color: str = None, attrs: list = None):
+        """Writes the text to the file, optionally with formatting.
+
+        Args:
+            text (str): The text to write.
+            color (str, optional): Foreground color (e.g., 'red', 'green'). Defaults to None.
+            on_color (str, optional): Background color (e.g., 'on_red', 'on_green'). Defaults to None.
+            attrs (list, optional): Additional text attributes (e.g., ['bold', 'underline']). 
+                                    Defaults to None.
+        """
+        if self.use_formatting:
+            formatted_text = termcolor.colored(text, color=color, on_color=on_color, attrs=attrs)
+        else:
+            formatted_text = text
+        
+        # Open the file in append mode, creating it if it doesn't exist
+        with open(self.file_path, 'a') as file:
+            file.write(formatted_text + '\n')

--- a/torchkernels/feature_maps/ridge_regression/random_features_ridge_regression.py
+++ b/torchkernels/feature_maps/ridge_regression/random_features_ridge_regression.py
@@ -1,0 +1,324 @@
+import torch, math
+import time
+from torcheval.metrics.functional import r2_score
+from torcheval.metrics import MeanSquaredError
+from ..orthogonal_random_features import ORF_w
+from ..random_fourier_features import RFF_w
+from .__init__ import FormattedFileWriter
+import json
+from torchmetrics.classification import MulticlassCalibrationError
+
+
+torch.manual_seed(42)
+torch.set_default_dtype(torch.float64)
+
+if torch.cuda.is_available():
+    DEVICE = torch.device("cuda")
+    DEV_MEM = (torch.cuda.get_device_properties(DEVICE).total_memory // 1024**3 - 1)  # GPU memory in GB, keeping aside 1GB for safety
+else:
+    DEVICE = torch.device("cpu")
+    DEV_MEM = 8  # RAM available for computing
+    
+class RFF_ridge_regression:
+    """_summary_
+    Class for training of RFF EigenPro2
+    Attributes:
+        n_train: Number of training samples
+        n_label: Number of classes/regressors
+        d_dim: number of columns in the dataset
+        W: Weight matrix (Kernel dependent)
+        b: Bias vector
+        c1: Scaling factor as per Random Fourier Features paper
+        Phi_train_samp: Random features for training subsamples as per EigenPro2
+        a_sol: Solution to the optimization problem
+        y_train_eval: Labels for training samples to be evaluated
+    """
+    def __init__(self, 
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        length_scale: float = 1.0,
+        kernel: str = "Laplace",
+        nu: float = 1.5,
+        alpha: float = 0.7,
+        p_feat: int = 10_000,
+        Sampling_Scheme: str = "RFF",
+        Rf_Bias: bool = True,
+        ridge_lambda: list = [1e-2],
+        n_train_eval: int = None,
+        metric: str = "R2Score"):
+        """_summary_
+        Initializes the RFF_ridge_regression class
+        Args:
+            X_train (torch.tensor): Training data
+            y_train (torch.tensor): Training labels
+            X_test (torch.tensor): Test data
+            y_test (torch.tensor): Test labels
+            length_scale (float, optional): length_scale of the Kernel. Defaults to 1.0.
+            kernel (str, optional): One of Laplace or Gauss or Matern. Defaults to "Laplace".
+            nu (float, optional): shape parameter for Matern kernel. Defaults to 1.5.
+            alpha (float, optional): shape parameter for ExpPower kernel. Defaults to 0.7.
+            p_feat (int, optional): Number of random features. Defaults to 10_000.
+            Sampling_Scheme (str, optional): One of RFF, ORF. Defaults to "RFF".
+            Rf_Bias (bool, optional): Random features use bias or are based on SinCos formulation. Defaults to True.
+            ridge_lambda (list, optional): Explicit ridge penalty. Defaults to 1e-2.
+            n_train_eval (int, optional): Number of training samples to be evaluated for training metrics. Defaults to None.
+            metric (str, optional): One of R2Score, MSE and Accuracy. Defaults to "R2Score".
+        """
+        self.X_train = X_train
+        self.y_train = y_train.to(DEVICE)
+        self.X_test = X_test
+        self.y_test = y_test.to(DEVICE)
+        del X_train, y_train, X_test, y_test
+        self.length_scale = length_scale
+        self.kernel_type = kernel
+        self.nu = nu
+        self.alpha = alpha
+        self.p_feat = p_feat
+        self.Sampling_Scheme = Sampling_Scheme
+        self.Rf_Bias = Rf_Bias
+        self.lambda_ = ridge_lambda
+        self.n_train_eval = n_train_eval
+        self.metric = metric
+        self.d_dim = self.X_train.shape[1]
+        self.n_label = self.y_train.shape[1]
+        self.n_train = self.X_train.shape[0]
+        print(self.X_train.shape, self.X_test.shape, self.y_train.shape, self.y_test.shape)
+        
+    def set_basic_params(self):
+        if self.n_train_eval is None:
+            self.n_train_eval = self.n_train // 10
+
+        self.train_eval_ids = torch.randperm(self.n_train)[ : min(self.n_train, self.n_train_eval)]
+
+    def get_max_bs(self):
+        print(f"Memory available: {DEV_MEM} GB")
+        b1 = (DEV_MEM*1024**3/(8*self.p_feat))
+        b2 = self.p_feat + self.d_dim + 2
+        self.batch_size = int(0.25*(b1-b2))
+        print(f"Batch size: {self.batch_size}")
+    
+    def write_attrs(self):
+        attributes_ = {
+        "length_scale": self.length_scale,
+        "kernel": self.kernel_type,
+        "p_feat": self.p_feat,
+        "Sampling_Scheme": self.Sampling_Scheme,
+        "Rf_Bias": self.Rf_Bias,
+        "batch_size": self.batch_size,
+        "n_train_eval": self.n_train_eval,
+        "metric": self.metric,
+        "time": time.ctime()
+        }
+        if self.kernel_type == "ExpPower":
+            attributes_["alpha"] = self.alpha
+        elif self.kernel_type == "Matern":
+            attributes_["nu"] = self.nu
+        
+        print(f"{'Attribute':>20}  {'Value':<20}")
+        print("=" * 42)
+        rows = []
+        row = ""
+        for i, (key, value) in enumerate(attributes_.items()):
+            row += f"{key:>20}  {str(value):<20}  "
+            # Print the row every three items or on the last item
+            if (i + 1) % 3 == 0 or i == len(attributes_) - 1:
+                rows.append(row)
+                row = ""
+        for r in rows:
+            print(r)
+        self.atts = attributes_
+    
+    def get_W_b_c(self) -> None:
+        """_summary_
+        Generates W, b, c parameters depending on the kernel and scheme.
+        Uses:
+            self.p_feat (int): Number of random features
+            self.d_dim (int): Dimension of the data
+            self.kernel_type (str, optional): Defaults to "Laplace".
+            self.Sampling_scheme (str, optional): Defaults to "ORF".
+        """
+        if not self.Rf_Bias:
+            p_feat = self.p_feat // 2
+        else: p_feat = self.p_feat
+        
+        scheme = self.Sampling_Scheme
+        d = self.d_dim
+
+        if scheme == "ORF":
+            Q, R_dist = ORF_w(p_feat=p_feat, d_dim=d, Kernel=self.kernel_type, length_scale=self.length_scale, nu=self.nu, alpha=self.alpha)
+            self.Q = Q.to(torch.float64).to(DEVICE)  # On GPU
+            self.R_dist = R_dist.to(torch.float64).to(DEVICE)  # On GPU
+            del Q, R_dist
+            self.b = ((torch.rand(p_feat) * math.pi * 2).to(torch.float64).to(DEVICE))  # On GPU
+            self.c1 = (torch.sqrt(torch.tensor(2 / p_feat)).to(torch.float64).to(DEVICE))  # On GPU
+        elif scheme == "RFF":
+            W1, W2 = RFF_w(p_feat=p_feat, d_dim=d, Kernel=self.kernel_type, length_scale=self.length_scale, nu=self.nu, alpha=self.alpha)
+            self.W1 = W1.to(torch.float64).to(DEVICE)  # On GPU
+            self.W2 = W2.to(torch.float64).to(DEVICE)  # On GPU
+            self.b = ((torch.rand(p_feat) * math.pi * 2).to(torch.float64).to(DEVICE))  # On GPU
+            self.c1 = (torch.sqrt(torch.tensor(2 / p_feat)).to(torch.float64).to(DEVICE))  # On GPU
+
+    def create_random_features(self, X_):
+        """_summary_
+        Creates random features for data X_
+        Args:
+            X_ (_type_): Data for which random features are to be generated
+            W (_type_): Weight Matrix (kernel dependent)
+            b (_type_): Bias term, not used if Rf_Bias is False
+            c1 (_type_): Normalization factor as per Random Fourier Features paper
+            Rf_Bias (bool, optional): If random features include bias term or as SinCos features. Defaults to True.
+
+        Returns:
+            Random features created using W, b, c parameters for X_. Created on the GPU.
+        """
+        torch.cuda.empty_cache()
+        X_ = X_.to(DEVICE)  # On GPU
+        if self.Rf_Bias and self.Sampling_Scheme == 'ORF':
+            return self.c1 * ((torch.mm(X_, self.Q)*self.R_dist) + self.b).cos()
+        elif self.Rf_Bias and self.Sampling_Scheme == 'RFF' and self.kernel_type in ['Laplace', 'Matern']:
+            return self.c1 * ((torch.mm(X_, self.W1)/self.W2) + self.b).cos()
+        elif self.Rf_Bias and self.Sampling_Scheme == 'RFF' and self.kernel_type in ['Gauss', 'ExpPower']:
+            return self.c1 * ((torch.mm(X_, self.W1)*self.W2) + self.b).cos()
+        
+        if not self.Rf_Bias and self.Sampling_Scheme == 'ORF':
+            return self.c1 * torch.cat([(torch.mm(X_, self.Q)*self.R_dist).cos(), (torch.mm(X_, self.Q)*self.R_dist).sin()], dim=-1)
+        elif not self.Rf_Bias and self.Sampling_Scheme == 'RFF' and self.kernel_type in ['Laplace', 'Matern']:
+            return self.c1 * torch.cat([(torch.mm(X_, self.W1)/self.W2).cos(), (torch.mm(X_, self.W1)/self.W2).sin()], dim=-1)
+        elif not self.Rf_Bias and self.Sampling_Scheme == 'RFF' and self.kernel_type in ['Gauss', 'ExpPower']:
+            return self.c1 * torch.cat([(torch.mm(X_, self.W1)*self.W2).cos(), (torch.mm(X_, self.W1)*self.W2).sin()], dim=-1)
+    
+    def matrix_loader(self):
+        num_rows = self.X_train.shape[0]
+        for i in range(0, num_rows, self.batch_size):
+            yield self.X_train[i:i+self.batch_size]
+    
+    def y_train_loader(self):
+        num_rows = self.y_train.shape[0]
+        for i in range(0, num_rows, self.batch_size):
+            yield self.y_train[i:i+self.batch_size]
+        
+    def create_H(self):
+        self.Phi_t_Phi = torch.zeros((self.p_feat, self.p_feat), dtype=torch.float64)
+        i=0
+        for X_batch in self.matrix_loader():
+            Phi_batch = self.create_random_features(X_batch)
+            self.Phi_t_Phi += (Phi_batch.T @ Phi_batch).to('cpu')
+            del Phi_batch
+            torch.cuda.empty_cache()
+            time.sleep(1)
+            
+            i=i+1
+
+    def create_Phi_t_y(self):
+        self.Phi_t_ytrain = torch.zeros((self.p_feat, self.y_train.shape[1]), dtype=torch.float64)
+        for X_batch, y_batch in zip(self.matrix_loader(), self.y_train_loader()):
+            Phi_batch = self.create_random_features(X_batch)
+            y_batch = y_batch.to(DEVICE)
+            self.Phi_t_ytrain += (Phi_batch.T @ y_batch).to('cpu')
+            torch.cuda.empty_cache()
+    
+    def calc_metrics(self):
+        X_train_eval = self.X_train[self.train_eval_ids]
+        self.y_train_eval = self.y_train[self.train_eval_ids]  # On GPU
+        self.y_test = self.y_test.to(DEVICE)  # On GPU
+        y_train_hat = self.forward(X_train_eval)  # On GPU
+        y_test_hat = self.forward(self.X_test)  # On GPU
+        if self.metric == "R2Score":
+            self.train_score = r2_score(y_train_hat, self.y_train_eval).item()
+            self.test_score = r2_score(y_test_hat, self.y_test).item()
+        elif self.metric == "Accuracy":
+            y_train_hat = torch.argmax(y_train_hat, dim=1)
+            y_test_hat = torch.argmax(y_test_hat, dim=1)
+            torch.cuda.empty_cache()
+            y_train_eval = torch.argmax(self.y_train_eval, dim=1)
+            y_test = torch.argmax(self.y_test, dim=1)
+            self.train_score = (y_train_hat == y_train_eval).sum().item()/self.y_train_eval.shape[0]
+            self.test_score = (y_test_hat == y_test).sum().item()/self.y_test.shape[0]
+        elif self.metric == "Bin_Acc":
+            y_sign = torch.sign(self.y_train_eval)
+            y_sign_pred = torch.sign(y_train_hat)
+            self.train_score = (y_sign == y_sign_pred).float().mean().item()
+            y_sign = torch.sign(self.y_test)
+            y_sign_pred = torch.sign(y_test_hat)
+            self.test_score = (y_sign == y_sign_pred).float().mean().item()
+        elif self.metric == "MSE":
+            metric = MeanSquaredError(device=DEVICE)
+            metric.update(y_train_hat, self.y_train_eval)
+            self.train_score = metric.compute().item()
+            metric.update(y_test_hat, self.y_test)
+            self.test_score = metric.compute().item()
+            del metric
+        elif self.metric == "ECE":
+            mcce = MulticlassCalibrationError(num_classes=10, n_bins=15, norm='l2')
+            y_train_eval = torch.argmax(self.y_train_eval, dim=1)
+            y_test = torch.argmax(self.y_test, dim=1)
+            y_train_hat_softmax = torch.softmax(y_train_hat, dim = 1)
+            y_test_hat_softmax = torch.softmax(y_test_hat, dim = 1)
+            self.train_score = mcce(y_train_hat_softmax, y_train_eval).item()
+            self.test_score = mcce(y_test_hat_softmax, y_test).item()
+        del y_train_hat, y_test_hat, X_train_eval
+        torch.cuda.empty_cache()
+
+    def forward(self, X_):
+        """_summary_
+        Does Phi(X) @ a_sol in a way where memory overflow does not occur
+        Args:
+            X_ (torch.tensor): Value for which prediction is to be made
+        Returns:
+            y_hat: Prediction corresponding to X_, stored on GPU
+        """
+        n_samples = X_.shape[0]
+        batches = torch.randperm(n_samples).split(self.batch_size)
+        y_hat = torch.zeros(n_samples, self.n_label, device=DEVICE) # On GPU
+        for _, b_ids in enumerate(batches):
+            self.PHI = self.create_random_features(X_[b_ids])  # On GPU
+            y_hat[b_ids] = self.PHI @ self.a_sol  # On GPU
+            # print(colored(f"Current allocated memory {torch.cuda.memory_allocated()/(1024**3):,.4f}", "light_red"),"GB")
+            del self.PHI
+            torch.cuda.empty_cache()
+        return y_hat  # On GPU
+
+    def fit(self):
+        self.start_time = time.time()
+        self.set_basic_params()
+        self.get_max_bs()
+        self.write_attrs()
+        self.get_W_b_c()
+        self.create_H()
+        print("H computed")
+        self.create_Phi_t_y()
+        self.Phi_t_ytrain = self.Phi_t_ytrain.to(DEVICE)
+        stop_time = time.time()
+        print(f"Matrix assembly time: {stop_time - self.start_time:.2f}")
+        metric_dict ={"train":{},
+                      "test":{}}
+        for r_lam in self.lambda_:
+            r_lam_str = f'{r_lam:.0e}'
+            inv_start_time = time.time()
+            self.Phi_t_Phi_lam = (self.Phi_t_Phi + r_lam * torch.eye(self.p_feat)).to(DEVICE)
+            self.a_sol = torch.linalg.solve(self.Phi_t_Phi_lam, self.Phi_t_ytrain)
+            print(f"Inversion time: {time.time() - inv_start_time:.2f}")
+            del self.Phi_t_Phi_lam
+            torch.cuda.empty_cache()
+            self.calc_metrics()
+            print(f"lambda: {r_lam:.4E} \t train_score: {self.train_score:.4f} \t test_score: {self.test_score:.4f}")
+            metric_dict["train"][r_lam_str] = self.train_score
+            metric_dict["test"][r_lam_str] = self.test_score
+        return metric_dict
+
+
+n = 20_000  # number of samples
+d = 8  # dimensions
+c = 1  # number of targets
+w_star = torch.rand(d, c)
+normalize = lambda x: x / x.norm(dim=-1, keepdim=True)
+x_train, x_test = normalize(torch.randn(n, d)), normalize(torch.randn(n // 2, d))
+y_train, y_test = torch.sign(x_train @ w_star), torch.sign(x_test @ w_star)
+p = 1000
+
+model = RFF_ridge_regression(x_train, y_train, x_test, y_test, p_feat=p, Rf_Bias=True, ridge_lambda=[1e-2, 1e-3, 1e-5, 1e-8],    
+                                kernel="ExpPower", metric="Bin_Acc", alpha=1.2)
+error_dict = model.fit()
+print("Ridge Regression test is complete")

--- a/torchkernels/feature_maps/utils.py
+++ b/torchkernels/feature_maps/utils.py
@@ -1,0 +1,42 @@
+import numpy as np
+import scipy.stats as stats
+def CMS_sampling(p, alpha, length_scale=1.):
+    r"""
+    Generate radial CMS given alpha, length_scale and dimension d. Samples generated are from $S(\alpha/2, 1, $2 \gamma^2 (cos(\pi \alpha/2))^(2/\alpha)$, 0)
+    
+    Parameters:
+        p (int): Number of samples
+        alpha (float): alpha for the multivariable alpha-stable distribution
+        length_scale (float): length_scale for the distribution, default is 1.
+    
+    Returns:
+        x (torch.tensor), shape (n,)): generated CMS samples
+    """
+    PI = np.pi
+    gamma_2 = 1/(float(length_scale))**2
+    sigma = 2 * gamma_2* (np.cos(PI*alpha/4))**(2/alpha)
+    if not 0. <= alpha <= 2.:
+        raise ValueError("Alpha must be between 0 and 2")
+    # generate random variables
+    v = np.random.uniform(-0.5 * PI, 0.5 * PI, p)
+    w = np.random.exponential(1, p)
+    
+    #alpha to be used in CMS is alpha/2 given alpha for multivariable stable distribution
+    alpha = float(alpha)/2
+    if alpha == 1.:
+        raise NotImplementedError("alpha = 1 is Laplace Kernel use that instead")
+    elif alpha == 2.:
+        raise NotImplementedError("alpha = 2 is Gaussian Kernel use that instead")
+    else:
+        arg1 = 0.5 * PI * alpha
+        b_ab = PI/2
+        s_ab = np.cos(arg1)**(-1/alpha)
+        arg2 = alpha * (v + b_ab)
+        n1 = np.sin(arg2)
+        d1 = np.cos(v)**(1/alpha)
+        n2 = np.cos(v - arg2)
+        x = sigma * s_ab * (n1/d1) * (n2/w)**((1-alpha)/alpha)
+        return x
+
+# if __name__ == "__main__":
+#     print(CMS_sampling(p=100, alpha=0.7, length_scale=1.))

--- a/torchkernels/kernels/radial.py
+++ b/torchkernels/kernels/radial.py
@@ -66,8 +66,7 @@ def exp_power(samples, centers=None, length_scale=1., alpha=1., M=None):
     if centers is None: centers = samples
     kernel_mat = euclidean(samples, centers, squared=True, M=M)
     kernel_mat.pow_(alpha /2.)
-    kernel_mat.div_(length_scale**alpha)
-    kernel_mat.neg_()
+    kernel_mat.div_(-length_scale**alpha)
     kernel_mat.exp_()
     return kernel_mat
     
@@ -76,13 +75,12 @@ def matern(samples, centers=None, length_scale=1., nu=1., M=None):
     X = samples.cpu().numpy()
     Z = centers.cpu().numpy()
     kernel = Matern(length_scale=length_scale, nu=nu)
-    K_mat = kernel.__call__(X, Z)
+    K_mat = kernel(X, Z)
     del X, Z
     return torch.from_numpy(K_mat).to(torch.float32)
 
 
 # Aliases
 exponential_power = exp_power
-dispersal = exp_power
 rbf = gaussian
 laplace = laplacian

--- a/torchkernels/kernels/radial.py
+++ b/torchkernels/kernels/radial.py
@@ -58,19 +58,19 @@ def gaussian(samples, centers=None, length_scale=1., M=None):
     kernel_mat.exp_()
     return kernel_mat
 
-def exp_power(samples, centers=None, length_scale=1., power=1., M=None):
+def exp_power(samples, centers=None, length_scale=1., alpha=1., M=None):
     '''
         K(x,z)=exp(-(\norm{x-z}_M/length_scale)^\alpha)
     '''
     assert length_scale > 0
     if centers is None: centers = samples
     kernel_mat = euclidean(samples, centers, squared=True, M=M)
-    kernel_mat.div_(length_scale)
-    kernel_mat.pow_(power / 2.)
+    kernel_mat.pow_(alpha /2.)
+    kernel_mat.div_(length_scale**alpha)
     kernel_mat.neg_()
     kernel_mat.exp_()
     return kernel_mat
-
+    
 def matern(samples, centers=None, length_scale=1., nu=1., M=None):
     if M is not None: raise NotImplementedError
     X = samples.cpu().numpy()
@@ -78,7 +78,7 @@ def matern(samples, centers=None, length_scale=1., nu=1., M=None):
     kernel = Matern(length_scale=length_scale, nu=nu)
     K_mat = kernel.__call__(X, Z)
     del X, Z
-    return torch.from_numpy(K_mat, dtype=torch.float32)
+    return torch.from_numpy(K_mat).to(torch.float32)
 
 
 # Aliases

--- a/torchkernels/kernels/radial.py
+++ b/torchkernels/kernels/radial.py
@@ -1,73 +1,84 @@
 from ..linalg import euclidean
 from .__init__ import Kernel
 import torch
+from sklearn.gaussian_process.kernels import Matern
 
 
 class RadialKernel(Kernel):
     '''
-        K(x,z)=phi(-\norm{x-z}_M / bandwidth) where phi is specified in subclass
+        K(x,z)=phi(-\norm{x-z}_M / length_scale) where phi is specified in subclass
     '''
-    def __init__(self, fn=None, bandwidth=1., squared=True):
+    def __init__(self, fn=None, length_scale=1., squared=True):
         super().__init__()
         self.fn = fn
         self.squared = squared
-        assert bandwidth > 0, "argument `bandwidth` must be positive."
-        self.bandwidth = 2 * bandwidth**2 if squared else bandwidth
+        assert length_scale > 0, "argument `length_scale` must be positive."
+        self.length_scale = 2 * length_scale**2 if squared else length_scale
 
     def __call__(self, samples, centers=None, M=None, **kwargs):
         if centers is None: 
             centers = samples
         matrix = euclidean(samples, centers, squared=self.squared, M=M)
-        matrix.div_(-self.bandwidth)
+        matrix.div_(-self.length_scale)
         # if matrix.device=='cuda': raise NotImplementedError("Currently `torch.Tensor.apply_` is not supported on CUDA")
         matrix = self.fn(matrix)
         return matrix
 
 class LaplacianKernel(RadialKernel):
-    def __init__(self, bandwidth=1.):
-        super().__init__(fn=lambda x: torch.exp(x), bandwidth=bandwidth, squared=False)
+    def __init__(self, length_scale=1.):
+        super().__init__(fn=lambda x: torch.exp(x), length_scale=length_scale, squared=False)
     
 class GaussianKernel(RadialKernel):
-    def __init__(self, bandwidth=1.):
-        super().__init__(fn=lambda x: torch.exp(x), bandwidth=bandwidth, squared=True)
+    def __init__(self, length_scale=1.):
+        super().__init__(fn=lambda x: torch.exp(x), length_scale=length_scale, squared=True)
     
 class ExponentialPowerKernel(RadialKernel):
-    def __init__(self, bandwidth=1.):
-        super().__init__(fn=lambda x: torch.exp(torch.pow(power/2)), bandwidth=bandwidth, squared=True)
+    def __init__(self, length_scale=1., power=1.):
+        super().__init__(fn=lambda x: torch.exp(torch.pow(x, power/2)), length_scale=length_scale, squared=True)
 
-def laplacian(samples, centers=None, bandwidth=1., M=None):
+def laplacian(samples, centers=None, length_scale=1., M=None):
     '''
-        K(x,z)=exp(-\norm{x-z}_M / bandwidth)
+        K(x,z)=exp(-\norm{x-z}_M / length_scale)
     '''
-    assert bandwidth > 0
+    assert length_scale > 0
     if centers is None: centers = samples
     kernel_mat = euclidean(samples, centers, squared=False, M=M)
-    kernel_mat.div_(-bandwidth)
+    kernel_mat.div_(-length_scale)
     kernel_mat.exp_()
     return kernel_mat
 
-def gaussian(samples, centers=None, bandwidth=1., M=None):
+def gaussian(samples, centers=None, length_scale=1., M=None):
     '''
-        K(x,z)=exp(-\norm{x-z}_M^2 / 2/bandwidth^2)
+        K(x,z)=exp(-\norm{x-z}_M^2 / 2/length_scale^2)
     '''
-    assert bandwidth > 0
+    assert length_scale > 0
     if centers is None: centers = samples
     kernel_mat = euclidean(samples, centers, squared=True, M=M)
-    kernel_mat.div_(-2 * bandwidth ** 2)
+    kernel_mat.div_(-2 * length_scale ** 2)
     kernel_mat.exp_()
     return kernel_mat
 
-def exp_power(samples, centers=None, bandwidth=1., power=1., M=None):
+def exp_power(samples, centers=None, length_scale=1., power=1., M=None):
     '''
-        K(x,z)=exp(-\norm{x-z}_M^\gamma / bandwidth)
+        K(x,z)=exp(-(\norm{x-z}_M/length_scale)^\alpha)
     '''
-    assert bandwidth > 0
+    assert length_scale > 0
     if centers is None: centers = samples
     kernel_mat = euclidean(samples, centers, squared=True, M=M)
+    kernel_mat.div_(length_scale)
     kernel_mat.pow_(power / 2.)
-    kernel_mat.div_(-bandwidth)
+    kernel_mat.neg_()
     kernel_mat.exp_()
     return kernel_mat
+
+def matern(samples, centers=None, length_scale=1., nu=1., M=None):
+    if M is not None: raise NotImplementedError
+    X = samples.cpu().numpy()
+    Z = centers.cpu().numpy()
+    kernel = Matern(length_scale=length_scale, nu=nu)
+    K_mat = kernel.__call__(X, Z)
+    del X, Z
+    return torch.from_numpy(K_mat, dtype=torch.float32)
 
 
 # Aliases

--- a/torchkernels/linalg/rp_cholesky.py
+++ b/torchkernels/linalg/rp_cholesky.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     from torchkernels.kernels.radial import LaplacianKernel
     
-    K = LaplacianKernel(bandwidth=1.)
+    K = LaplacianKernel(length_scale=1.)
 
     n, d, k = 100, 2, 20
     X = torch.randn(n, d)

--- a/torchkernels/solvers/axlepro_test.py
+++ b/torchkernels/solvers/axlepro_test.py
@@ -11,7 +11,7 @@ from torchmetrics.functional import mean_squared_error as mse
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(0)
 
-K = LaplacianKernel(bandwidth=1.)
+K = LaplacianKernel(length_scale=1.)
 n, d, c, s, q = 1000, 3, 2, 100, 10
 epochs = 1000
 

--- a/torchkernels/solvers/cg_test.py
+++ b/torchkernels/solvers/cg_test.py
@@ -7,7 +7,7 @@ from ..kernels.radial import LaplacianKernel
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(0)
 
-K = LaplacianKernel(bandwidth=1.)
+K = LaplacianKernel(length_scale=1.)
 n, d, c = 1000, 3, 1
 X = torch.randn(n, d)
 y = torch.randn(n, c)

--- a/torchkernels/solvers/eigenpro2_test.py
+++ b/torchkernels/solvers/eigenpro2_test.py
@@ -11,7 +11,7 @@ import math
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(0)
 
-K = LaplacianKernel(bandwidth=1.)
+K = LaplacianKernel(length_scale=1.)
 n, d, c, s, q = 1000, 3, 2, 100, 20
 epochs = 1000
 

--- a/torchkernels/solvers/eigenpro_test.py
+++ b/torchkernels/solvers/eigenpro_test.py
@@ -9,7 +9,7 @@ from ..linalg.fmm import KmV
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(0)
 
-K = LaplacianKernel(bandwidth=1.)
+K = LaplacianKernel(length_scale=1.)
 n, d, c, q = 1000, 3, 2, 30
 X = torch.randn(n, d)/math.sqrt(d)
 y = torch.randn(n, c)

--- a/torchkernels/solvers/mass.py
+++ b/torchkernels/solvers/mass.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     torch.manual_seed(0)
     torch.set_default_dtype(torch.float64)
 
-    K = LaplacianKernel(bandwidth=1.)
+    K = LaplacianKernel(length_scale=1.)
     n, d, c = 1000, 3, 2
     X = torch.randn(n, d)
     y = torch.randn(n, c)

--- a/torchkernels/solvers/multistep.py
+++ b/torchkernels/solvers/multistep.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     torch.set_default_dtype(torch.float64)
     torch.manual_seed(0)
 
-    K = LaplacianKernel(bandwidth=1.)
+    K = LaplacianKernel(length_scale=1.)
     n, d, c, q, m = 100, 3, 2, 1, None
     X = torch.randn(n, d)
     y = torch.randn(n, c)


### PR DESCRIPTION
Added Random Features implementation for the Laplace, Gauss, Matern and ExpPower kernels.
Changed every instance of bandwidth to length_scale. 
Added matern kernel implementation as part of torchkernels.kernels.radial - it currently just points to sklearn for evaluation. 

Tested above kernels for point wise approximation wrt ||x-z|| for the following cases

- ORF, RFF
- Bias: True, False i.e. +b or SinCos features.